### PR TITLE
fix black background when cropping a transparent background

### DIFF
--- a/src/lib/Image.php
+++ b/src/lib/Image.php
@@ -101,9 +101,18 @@ class Image
     }
 
     public function crop($x,$y,$width,$height){
-        $resource = imagecrop($this->getResource(), ['x' => $x, 'y' => $y, 'width' => $width, 'height' => $height]);
+        //CREATE NEW IMAGE BASED ON WIDTH AND HEIGHT OF SROUCE IMAGE
+        $bg = imagecreatetruecolor($width, $height);
+        $transparent = imagecolorallocatealpha($bg, 0, 0, 0, 127);
+        imagealphablending($bg, false);
+        imagesavealpha($bg, true);
+        imagefill($bg, 0, 0, $transparent);
+
+        //SAVE TRANSPARENCY AMD FILL DESTINATION IMAGE
+        imagecopy($bg, $this->getResource(), 0, 0, $x, $y, $width, $height);
         imagedestroy($this->getResource());
-        $this->setResource($resource);
+        $this->setResource($bg);
+
         return $this;
     }
 


### PR DESCRIPTION
I have an issue when cropping a transparent background. When I crop it the background became black, not transparent. It's happened in my hosting provider (PHP 8.0). 
And then I read this:
[https://stackoverflow.com/questions/54884501/php-gd-adds-black-background-around-cropped-source-image](https://stackoverflow.com/questions/54884501/php-gd-adds-black-background-around-cropped-source-image)

I have tested this and it works fine in my local machine (PHP 7.3) and in my hosting provider (PHP 8.0)